### PR TITLE
using c++14 make_unique for derived alg binding

### DIFF
--- a/src/mcmc_main.cpp
+++ b/src/mcmc_main.cpp
@@ -273,22 +273,18 @@ int main(int argc, char const *argv[]) {
       }
     }
     // Bind proper Metropolis-Hasting algorithm
-    metropolis_hasting* algorithm;
+    std::shared_ptr<metropolis_hasting> algorithm;
     if (!use_ppm && use_single_vertex) {
-        mh_single_vertex_sbm alg;
-        algorithm = &alg;
+        algorithm = std::make_shared<mh_single_vertex_sbm>();
     }
     else if (use_ppm && use_single_vertex) {
-        mh_single_vertex_ppm alg;
-        algorithm = &alg;
+        algorithm = std::make_shared<mh_single_vertex_ppm>();    
     }
     else if (!use_ppm &&  !use_single_vertex) {
-        mh_vertices_swap_sbm alg;
-        algorithm = &alg;
+        algorithm = std::make_shared<mh_vertices_swap_sbm>();     
     }
     else if (use_ppm && !use_single_vertex) {
-        mh_vertices_swap_ppm alg;
-        algorithm = &alg;
+        algorithm = std::make_shared<mh_vertices_swap_ppm>();     
     }
 
     /* ~~~~~ Logging ~~~~~~~*/


### PR DESCRIPTION
The original code might raise segmentation error for some compilers, due to a problem discussed in [this](https://stackoverflow.com/questions/15334831/calling-virtual-method-of-a-derived-class-causes-segfaults) Stack Overflow thread. 

A PR was made. Also, [current ISO standard](https://isocpp.org/std/the-standard) is C++14.